### PR TITLE
rename Sirupsen/logrus to sirupsen/logrus

### DIFF
--- a/goisilon_test.go
+++ b/goisilon_test.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
 	log "github.com/codedellemc/gournal"
 	glogrus "github.com/codedellemc/gournal/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )


### PR DESCRIPTION
Note that this patch won't really work until gournal is updated to to also do the rename.